### PR TITLE
Feature: Add comm_assoc keyword

### DIFF
--- a/src/Editor/ace-auto-complete-george.js
+++ b/src/Editor/ace-auto-complete-george.js
@@ -16,8 +16,7 @@ const words = [
   "true",
 
   // transformational
-  "comm",	
-  "assoc",
+  "comm_assoc",	
   "contr",
   "lem",
   "impl",

--- a/src/Editor/ace-mode-george.js
+++ b/src/Editor/ace-mode-george.js
@@ -41,7 +41,7 @@ ace.define("ace/mode/george_highlight_rules", ["require", "exports", "module", "
                 regex: /\b(?:true|false|empty|univ|N)\b/
             }, {
                 token: "constant.language.source.grg",
-                regex: /\b(?:and_i|and_e|or_i|or_e|lem|imp_e|not_e|not_not_i|not_not_e|iff_i|iff_e|trans|iff_mp|exists_i|forall_e|eq_i|eq_e|premise|raa|cases|imp_i|forall_i|exists_e|disprove|case|assume|for every|for some|and_nb|not_and_br|or_br|not_or_nb|imp_br|not_imp_nb|not_not_nb|iff_br|not_iff_br|forall_nb|not_forall_nb|exists_nb|not_exists_nb|closed|comm|assoc|contr|lem|impl|contrapos|simp1|simp2|distr|dm|neg|equiv|idemp|forall_over_and|exists_over_or|swap_vars|move_exists|move_forall|set|arith|Delta|Xi)\b/
+                regex: /\b(?:and_i|and_e|or_i|or_e|lem|imp_e|not_e|not_not_i|not_not_e|iff_i|iff_e|trans|iff_mp|exists_i|forall_e|eq_i|eq_e|premise|raa|cases|imp_i|forall_i|exists_e|disprove|case|assume|for every|for some|and_nb|not_and_br|or_br|not_or_nb|imp_br|not_imp_nb|not_not_nb|iff_br|not_iff_br|forall_nb|not_forall_nb|exists_nb|not_exists_nb|closed|comm_assoc|contr|lem|impl|contrapos|simp1|simp2|distr|dm|neg|equiv|idemp|forall_over_and|exists_over_or|swap_vars|move_exists|move_forall|set|arith|Delta|Xi)\b/
             }, {
                 token: "constant.numeric.source.grg",
                 regex: /\b(?:in|sube|sub|pow|union|inter|card|gen_U|dom|ran|id|iter|seq)\b/


### PR DESCRIPTION
In the [new version of George](https://student.cs.uwaterloo.ca/~se212/george/george-docs-1/tp.html), the rules `comm` and `assoc` have been removed in favour of a new  `comm_assoc` rule. This PR adds `comm_assoc` as a keyword in Boole so that it is properly highlighted and removes the deprecated `comm` and `assoc` keywords.