### PR TITLE
Add support for Vim and Emacs key bindings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -895,16 +895,6 @@
         "regexpu-core": "^4.5.4"
       }
     },
-    "@babel/polyfill": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
-      "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
-      }
-    },
     "@babel/preset-env": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.0.tgz",
@@ -1632,6 +1622,12 @@
         "loader-utils": "^1.2.3"
       }
     },
+    "@types/ace": {
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@types/ace/-/ace-0.0.47.tgz",
+      "integrity": "sha512-VoMFn09L8avwV0AGIaStj1MCJmgHKiPAGZYnmeHYp4Pz+ov4h/F61LJNFvq4d4K+YZmk0ClWByCDU81kZyCfoA==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
@@ -2000,6 +1996,12 @@
         "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
       }
+    },
+    "ace-builds": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.12.tgz",
+      "integrity": "sha512-G+chJctFPiiLGvs3+/Mly3apXTcfgE45dT5yp12BcWZ1kUs+gm0qd3/fv4gsz6fVag4mM0moHVpjHDIgph6Psg==",
+      "dev": true
     },
     "acorn": {
       "version": "7.2.0",
@@ -4466,9 +4468,9 @@
       }
     },
     "diff-match-patch": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.4.tgz",
-      "integrity": "sha512-Uv3SW8bmH9nAtHKaKSanOQmj2DnlH65fUpcrMdfdaOxUG02QQ4YGZ8AE7kKOMisF7UqvOlGKVYWRvezdncW9lg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
       "dev": true
     },
     "diff-sequences": {
@@ -12526,14 +12528,13 @@
       }
     },
     "react-ace": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-6.6.0.tgz",
-      "integrity": "sha512-Jehhp8bxa8kqiXk07Jzy+uD5qZMBwo43O+raniGHjdX7Qk93xFkKaAz8LxtUVZPJGlRnV5ODMNj0qHwDSN+PBw==",
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-9.4.3.tgz",
+      "integrity": "sha512-WKknvcOZLhMtTSicRll94SjfZe6XEvZO6OpjJQCUGDcygZwfopkizeVntHX2ldMystbcmVES1RrjXUmyw0+wfQ==",
       "dev": true,
       "requires": {
-        "@babel/polyfill": "^7.4.4",
-        "brace": "^0.11.1",
-        "diff-match-patch": "^1.0.4",
+        "ace-builds": "^1.4.12",
+        "diff-match-patch": "^1.0.5",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
         "prop-types": "^15.7.2"

--- a/package.json
+++ b/package.json
@@ -35,14 +35,17 @@
     "not op_mini all"
   ],
   "devDependencies": {
+    "@types/ace": "0.0.47",
+    "ace-builds": "^1.4.12",
     "axios": "^0.18.1",
     "brace": "^0.11.1",
     "http-proxy-middleware": "^0.20.0",
     "node-sass-chokidar": "^1.4.0",
     "npm-run-all": "^4.1.3",
     "react": "^16.6.3",
-    "react-ace": "^6.2.0",
+    "react-ace": "^9.4.3",
     "react-dom": "^16.6.3",
     "react-scripts": "^3.1.1"
-  }
+  },
+  "dependencies": {}
 }

--- a/src/App/index.jsx
+++ b/src/App/index.jsx
@@ -10,6 +10,7 @@ import DownloadButton from "../DownloadButton";
 import FileExplorer from "../FileExplorer";
 import Editor from "../Editor";
 import Output from "../Output";
+import KeyboardHandlerDropdown from "../KeyboardHandlerDropdown";
 
 export default class App extends Component {
   constructor(props) {
@@ -21,7 +22,8 @@ export default class App extends Component {
       value: "",
       feedback: "Click the \"Ask George\" button to get feedback.",
       feedbackExpanded: false,
-      openFile: null
+      openFile: null,
+      keyboardHandler: "windows",
     };
   }
 
@@ -48,6 +50,10 @@ export default class App extends Component {
     if (this.state.openFile !== null) this.state.openFile.set(value);
   };
 
+  onKeyboardHandlerChange = (keyboardHandler) => {
+    this.setState({ keyboardHandler });
+  }
+
   render() {
     return (
       <div className={"app" + (this.state.feedbackExpanded ? " app-expand-feedback" : "")}>
@@ -67,6 +73,10 @@ export default class App extends Component {
             <DownloadButton
               onDownload={this.onDownload}
             />
+
+            <KeyboardHandlerDropdown 
+              onKeyboardHandlerChange={this.onKeyboardHandlerChange}
+            />
           </ControlBar>
         </div>
 
@@ -82,6 +92,7 @@ export default class App extends Component {
             ref={this.editor}
             value={this.state.value}
             onValueChange={this.onValueChange}
+            keyboardHandler={this.state.keyboardHandler}
           />
         </div>
 

--- a/src/ControlBar/index.jsx
+++ b/src/ControlBar/index.jsx
@@ -7,9 +7,13 @@ export default class ControlBar extends Component {
     return (
       <div className="control-bar">
         {this.props.children}
-        <a href="https://github.com/ShazzAmin/Boole">Contribute on GitHub</a>
+        <a
+          href="https://github.com/ShazzAmin/Boole"
+          className="contribute-link"
+        >
+          Contribute on GitHub
+        </a>
       </div>
     );
   }
 }
-

--- a/src/ControlBar/styles.scss
+++ b/src/ControlBar/styles.scss
@@ -9,10 +9,10 @@
   margin: 0;
   color: $accent-color;
   background-color: $secondary-color;
-  box-shadow: 0px 5px 0px 0px rgba(255,255,255,0.75);
+  box-shadow: 0px 5px 0px 0px rgba(255, 255, 255, 0.75);
   display: grid;
   grid-gap: 20px;
-  grid-template-columns: min-content min-content auto;
+  grid-template-columns: min-content min-content auto max-content;
   grid-auto-flow: column;
 
   > * {
@@ -34,3 +34,6 @@
   }
 }
 
+.contribute-link {
+  justify-self: end;
+}

--- a/src/Editor/index.jsx
+++ b/src/Editor/index.jsx
@@ -5,10 +5,12 @@ import { UndoManager } from "brace";
 import "brace/theme/idle_fingers";
 import "brace/ext/searchbox";
 import "ace-builds/src-noconflict/keybinding-vim";
+import "ace-builds/src-noconflict/keybinding-emacs";
 
 import "./styles.css";
 import "./ace-mode-george";
 import "./ace-auto-complete-george";
+
 export default class Editor extends Component {
   static propTypes = {
     value: PropTypes.string.isRequired,

--- a/src/Editor/index.jsx
+++ b/src/Editor/index.jsx
@@ -4,15 +4,16 @@ import AceEditor from "react-ace";
 import { UndoManager } from "brace";
 import "brace/theme/idle_fingers";
 import "brace/ext/searchbox";
+import "ace-builds/src-noconflict/keybinding-vim";
 
 import "./styles.css";
 import "./ace-mode-george";
 import "./ace-auto-complete-george";
-
 export default class Editor extends Component {
   static propTypes = {
     value: PropTypes.string.isRequired,
-    onValueChange: PropTypes.func
+    onValueChange: PropTypes.func,
+    keyboardHandler: PropTypes.string.isRequired
   };
 
   static defaultProps = {
@@ -61,6 +62,7 @@ export default class Editor extends Component {
           editorProps={{
             $blockScrolling: Infinity
           }}
+          keyboardHandler={this.props.keyboardHandler}
         />
       </div>
     );

--- a/src/KeyboardHandlerDropdown/index.jsx
+++ b/src/KeyboardHandlerDropdown/index.jsx
@@ -1,0 +1,55 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import LocalStorage from "../common/local-storage";
+
+import "./styles.scss"
+
+export default class KeyboardHandlerDropdown extends Component {
+  static propTypes = {
+    onKeyboardHandlerChange: PropTypes.func,
+  };
+
+  static defaultProps = {
+    onKeyboardHandlerChange: () => {},
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.dropdown = React.createRef();
+  }
+
+  componentDidMount = () => {
+    LocalStorage.get("keyboard_handler")
+      .then((keyboardHandler) => {
+        if (keyboardHandler) {
+          this.props.onKeyboardHandlerChange(keyboardHandler);
+          this.dropdown.current.value = keyboardHandler;
+        }
+      })
+      .catch(() => {});
+  };
+
+  handleChange = (e) => {
+    this.props.onKeyboardHandlerChange(e.target.value);
+    LocalStorage.set("keyboard_handler", e.target.value);
+  };
+
+  render() {
+    return (
+      <div className="keyboard-handler-dropdown">
+        <label htmlFor="keyboard-handler">Key bindings:</label>
+        <select
+          name="keyboard-handler"
+          onChange={this.handleChange}
+          className="keyboard-handler-dropdown__select"
+          ref={this.dropdown}
+        >
+          <option value="windows">Default</option>
+          <option value="vim">Vim</option>
+          <option value="emacs">Emacs</option>
+        </select>
+      </div>
+    );
+  }
+}

--- a/src/KeyboardHandlerDropdown/index.jsx
+++ b/src/KeyboardHandlerDropdown/index.jsx
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import LocalStorage from "../common/local-storage";
 
-import "./styles.scss"
+import "./styles.scss";
 
 export default class KeyboardHandlerDropdown extends Component {
   static propTypes = {
@@ -37,19 +37,16 @@ export default class KeyboardHandlerDropdown extends Component {
 
   render() {
     return (
-      <div className="keyboard-handler-dropdown">
-        <label htmlFor="keyboard-handler">Key bindings:</label>
-        <select
-          name="keyboard-handler"
-          onChange={this.handleChange}
-          className="keyboard-handler-dropdown__select"
-          ref={this.dropdown}
-        >
-          <option value="windows">Default</option>
-          <option value="vim">Vim</option>
-          <option value="emacs">Emacs</option>
-        </select>
-      </div>
+      <select
+        name="keyboard-handler"
+        onChange={this.handleChange}
+        className="keyboard-handler-dropdown"
+        ref={this.dropdown}
+      >
+        <option value="windows">Default Keybindings</option>
+        <option value="vim">Vim Keybindings</option>
+        <option value="emacs">Emacs Keybindings</option>
+      </select>
     );
   }
 }

--- a/src/KeyboardHandlerDropdown/styles.scss
+++ b/src/KeyboardHandlerDropdown/styles.scss
@@ -1,12 +1,7 @@
 @import "../common/variables";
 
 .keyboard-handler-dropdown {
-  display: flex;
-  align-items: center;
   justify-self: end;
-}
-
-.keyboard-handler-dropdown__select {
   background-color: $secondary-color;
   color: $accent-color;
   border: 1px solid $accent-color;

--- a/src/KeyboardHandlerDropdown/styles.scss
+++ b/src/KeyboardHandlerDropdown/styles.scss
@@ -1,0 +1,13 @@
+@import "../common/variables";
+
+.keyboard-handler-dropdown {
+  display: flex;
+  align-items: center;
+  justify-self: end;
+}
+
+.keyboard-handler-dropdown__select {
+  background-color: $secondary-color;
+  color: $accent-color;
+  border: 1px solid $accent-color;
+}


### PR DESCRIPTION
This PR adds support for Vim and Emacs key bindings to the editor.

A dropdown has been added in the control bar to allow for selecting the editor mode. 
![control bar](https://user-images.githubusercontent.com/39220101/133349659-6867315b-13d6-4f9e-95ba-6003a9176e3c.png)

The default option is "Default", which means no special key bindings are applied. It sets `keyboardHandler` on `AceEditor` to `"windows"`. 
![dropdown](https://user-images.githubusercontent.com/39220101/133349885-e9af34d4-5ab2-47b5-988e-6ef71ff78b8d.png)
The dropdown contains two other modes: "Vim" and "Emacs". They respectively set `keyboardHandler` on the `AceEditor` component to `"vim"` and `"emacs"`.

The currently selected mode is persisted in local storage and is loaded and set by `KeyboardHandlerDropdown`.